### PR TITLE
Link to canonical repo + archive repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+⚠️ The canonical repo for this project is now located at https://github.com/Shopify/erb-lint ⚠️
+
 # ERB Lint [![Build Status](https://travis-ci.org/justinthec/erb-lint.svg?branch=master)](https://travis-ci.org/justinthec/erb-lint)
 
 `erb-lint` is a tool to help lint your ERB or HTML files using the included linters or by writing your own.


### PR DESCRIPTION
Two suggestions:
- Link to the canonical repo
- Archive this repo: https://docs.github.com/en/repositories/archiving-a-github-repository/archiving-repositories